### PR TITLE
Allow "stringable" objects on task name definition

### DIFF
--- a/src/ConsoleBrowser.php
+++ b/src/ConsoleBrowser.php
@@ -65,7 +65,7 @@ class ConsoleBrowser implements ConsoleBrowserContract
 
         if (! $this->inSecret) {
             foreach ($arguments as $argument) {
-                if (\is_string($argument)) {
+                if (\is_string($argument) || (\is_object($argument) && \is_callable([$argument, '__toString']))) {
                     $description .= " <info>$argument</info>";
                 }
             }


### PR DESCRIPTION
This is a small behaviour change to improve the output task names when using Dusk Pages for navigation (or any other methods that include objects).

When doing `->visit(new SomeCustomPage())` i.e, currently it will display only the method name:

![image](https://user-images.githubusercontent.com/1116377/62565378-082ac200-b85d-11e9-97c8-86db3dc829bc.png)

So by allowing objects casting to string, we can easily add that to our pages when necessary, as well as any other object parameters we might have in custom Page methods.

![image](https://user-images.githubusercontent.com/1116377/62565647-9bfc8e00-b85d-11e9-9ec0-165ab4b6c4a4.png)



PS: sorry about *stringable*, is there a correct term for these objects? 😄 