### PR TITLE
Add ChromeDriver command

### DIFF
--- a/src/LaravelConsoleDuskServiceProvider.php
+++ b/src/LaravelConsoleDuskServiceProvider.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace NunoMaduro\LaravelConsoleDusk;
 
-use Laravel\Dusk\Browser;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Dusk\Browser;
 use Laravel\Dusk\Console\ChromeDriverCommand;
 use NunoMaduro\LaravelConsoleDusk\Contracts\ManagerContract;
 

--- a/src/LaravelConsoleDuskServiceProvider.php
+++ b/src/LaravelConsoleDuskServiceProvider.php
@@ -43,7 +43,7 @@ class LaravelConsoleDuskServiceProvider extends ServiceProvider
         });
 
         $this->commands([
-            ChromeDriverCommand::class
+            ChromeDriverCommand::class,
         ]);
     }
 

--- a/src/LaravelConsoleDuskServiceProvider.php
+++ b/src/LaravelConsoleDuskServiceProvider.php
@@ -8,6 +8,7 @@ use Laravel\Dusk\Browser;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Dusk\Console\ChromeDriverCommand;
 use NunoMaduro\LaravelConsoleDusk\Contracts\ManagerContract;
 
 class LaravelConsoleDuskServiceProvider extends ServiceProvider
@@ -40,6 +41,10 @@ class LaravelConsoleDuskServiceProvider extends ServiceProvider
         $this->app->bind(ManagerContract::class, function ($app) {
             return new Manager();
         });
+
+        $this->commands([
+            ChromeDriverCommand::class
+        ]);
     }
 
     public function provides(): array


### PR DESCRIPTION
Adds the command `dusk:chrome-driver` used in dusk to update your chrome binaries. 

- It solves this issue from the `laravel-zero/framework`: https://github.com/laravel-zero/laravel-zero/issues/229

- This command is covered in the official `dusk` documentation, so I don't thinks it's necessary to update the readme: https://laravel.com/docs/6.x/dusk#managing-chromedriver-installations

Hope this helps!