### PR TITLE
chore(composer): update Dusk to latest versions

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-disabled:
-  - self_accessor

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "laravel/dusk": "^5.11",
+        "laravel/dusk": "^5.11|^6.0",
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
         "nunomaduro/laravel-console-task": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "laravel/dusk": "^5.0",
+        "laravel/dusk": "^5.11",
         "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
         "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
         "nunomaduro/laravel-console-task": "^1.0"

--- a/src/LaravelConsoleDuskServiceProvider.php
+++ b/src/LaravelConsoleDuskServiceProvider.php
@@ -20,7 +20,7 @@ class LaravelConsoleDuskServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/laravel-console-dusk.php' => config_path('laravel-console-dusk.php'),
-                ], 'config');
+            ], 'config');
 
             $manager = resolve(ManagerContract::class);
 


### PR DESCRIPTION
When including the latest version of this package with `--prefer-lowest`, it can cause an error because Dusk `<5.8.2` uses the old Facebook package so there is a duplicated class declaration.

See the [Laravel Zero CI](https://github.com/laravel-zero/framework/pull/403/checks?check_run_id=981169673#step:6:1) for an example of this.

---

Allowing support for v6 also allows this package to work with PHPUnit 9.