### PR TITLE
Add `@mixin` docblock for IDE autocompletion

### DIFF
--- a/src/ConsoleBrowser.php
+++ b/src/ConsoleBrowser.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use NunoMaduro\LaravelConsoleDusk\Contracts\ConsoleBrowserContract;
 
+/** @mixin Browser */
 class ConsoleBrowser implements ConsoleBrowserContract
 {
     protected $command;


### PR DESCRIPTION
`ConsoleBrowser` is proxying method calls to the underlying `Browser` instance with `__call()`, but IDEs have no way of knowing that. This simply adds a `@mixin Browser` docblock to the class so that IDEs will autocomplete correctly.

Without the docblock:
<img width="665" alt="Without the docblock" src="https://user-images.githubusercontent.com/748444/153676165-3c7bd839-bf2b-4604-9801-3e5221da0d89.png">

With the docblock:
<img width="491" alt="With the docblock" src="https://user-images.githubusercontent.com/748444/153676212-006002db-7383-4d62-8dbc-d2b201d3b48b.png">