### PR TITLE
feat: add documentation for Chrome Driver options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ return [
         'screenshots' => storage_path('laravel-console-dusk/screenshots'),
         'log'         => storage_path('laravel-console-dusk/log'),
     ],
+
+    /*
+    | --------------------------------------------------------------------------
+    | Headless Mode
+    | --------------------------------------------------------------------------
+    |
+    | When false it will show a Chrome window while running. Within production
+    | it will be forced to run in headless mode.
+    */
+    'headless' => true,
+
+    /*
+    | --------------------------------------------------------------------------
+    | Driver Configuration
+    | --------------------------------------------------------------------------
+    |
+    | Here you may pass options to the browser driver being automated.
+    |
+    | A list of available Chromium command line switches is available at
+    | https://peter.sh/experiments/chromium-command-line-switches/
+    */
+    'driver' => [
+        'chrome' => [
+            'options' => [
+                '--disable-gpu',
+            ],
+        ],
+    ],
 ];
 ```
 

--- a/config/laravel-console-dusk.php
+++ b/config/laravel-console-dusk.php
@@ -30,6 +30,9 @@ return [
     | --------------------------------------------------------------------------
     |
     | Here you may pass options to the browser driver being automated.
+    |
+    | A list of available Chromium command line switches is available at
+    | https://peter.sh/experiments/chromium-command-line-switches/
     */
     'driver' => [
         'chrome' => [


### PR DESCRIPTION
Hello,

This is an updated version of PR #27 that seems stalled waiting for the docs to be updated.

I simply updated the README.md with the updated version of the config file, which includes the default options and added the link to the list of Chromium command line switches as suggested.