### PR TITLE
chore(deps): update to require Laravel 9 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Laravel Console Dusk was created by, and is maintained by [Nuno Maduro](https://
 
 ## Installation
 
-> **Requires [PHP 7.2.5+](https://php.net/releases/)**
+> **Requires [PHP 8.1+](https://php.net/releases)**
 
 Require Laravel Console Dusk using [Composer](https://getcomposer.org):
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "laravel/dusk": "^5.11|^6.0|^7.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "nunomaduro/laravel-console-task": "^1.7"
+        "php": "^8.1",
+        "laravel/dusk": "^7.0|^8.0",
+        "illuminate/console": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
+        "nunomaduro/laravel-console-task": "^1.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This updates to require Laravel 9 or later, and PHP 8.1 or later.