### PR TITLE
Allow launching browsers without an Artisan command (for use in queues, etc.)

### DIFF
--- a/config/laravel-console-dusk.php
+++ b/config/laravel-console-dusk.php
@@ -17,6 +17,16 @@ return [
 
     /*
     | --------------------------------------------------------------------------
+    | Always Available Mode
+    | --------------------------------------------------------------------------
+    |
+    | Make Laravel Console Dusk available even when not running in the context
+    | of an Artisan command (e.g. from a queue worker).
+    */
+    'always_boot' => env('LCD_ALWAYS_BOOT', false),
+
+    /*
+    | --------------------------------------------------------------------------
     | Headless Mode
     | --------------------------------------------------------------------------
     |

--- a/src/ConsoleBrowser.php
+++ b/src/ConsoleBrowser.php
@@ -17,7 +17,7 @@ class ConsoleBrowser implements ConsoleBrowserContract
 
     protected $inSecret = false;
 
-    public function __construct(Command $command, Browser $browser)
+    public function __construct(Command|null $command, Browser $browser)
     {
         $this->command = $command;
         $this->browser = $browser;
@@ -39,6 +39,15 @@ class ConsoleBrowser implements ConsoleBrowserContract
     {
         $description = $this->getHumanReadableMethodDescription($name, $arguments);
 
+        if ($this->command) {
+            return $this->executeInConsole($description, $name, $arguments);
+        } else {
+            return $this->executeNoConsole($name, $arguments);
+        }
+    }
+
+    protected function executeInConsole($description, $name, $arguments)
+    {
         $exception = null;
         $result = null;
 
@@ -56,6 +65,12 @@ class ConsoleBrowser implements ConsoleBrowserContract
             throw $exception;
         }
 
+        return $result instanceof Browser ? $this : $result;
+    }
+
+    protected function executeNoConsole($name, $arguments)
+    {
+        $result = call_user_func_array([$this->browser, $name], $arguments);
         return $result instanceof Browser ? $this : $result;
     }
 

--- a/src/ConsoleBrowserFactory.php
+++ b/src/ConsoleBrowserFactory.php
@@ -17,7 +17,7 @@ class ConsoleBrowserFactory implements ConsoleBrowserFactoryContract
 
     protected $driver;
 
-    public function make(Command $command, DriverContract $driver): ConsoleBrowserContract
+    public function make(Command|null $command, DriverContract $driver): ConsoleBrowserContract
     {
         $this->driver = $driver;
 

--- a/src/Contracts/ConsoleBrowserFactoryContract.php
+++ b/src/Contracts/ConsoleBrowserFactoryContract.php
@@ -9,5 +9,5 @@ use NunoMaduro\LaravelConsoleDusk\Contracts\Drivers\DriverContract;
 
 interface ConsoleBrowserFactoryContract
 {
-    public function make(Command $command, DriverContract $driver): ConsoleBrowserContract;
+    public function make(Command|null $command, DriverContract $driver): ConsoleBrowserContract;
 }

--- a/src/Contracts/ManagerContract.php
+++ b/src/Contracts/ManagerContract.php
@@ -9,5 +9,5 @@ use Illuminate\Console\Command;
 
 interface ManagerContract
 {
-    public function browse(Command $command, Closure $callback): void;
+    public function browse(Command|null $command, Closure $callback): void;
 }

--- a/src/LaravelConsoleDuskServiceProvider.php
+++ b/src/LaravelConsoleDuskServiceProvider.php
@@ -16,7 +16,7 @@ class LaravelConsoleDuskServiceProvider extends ServiceProvider implements Defer
 {
     public function boot(): void
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() || config('laravel-console-dusk.always_boot')) {
             $this->publishes([
                 __DIR__.'/../config/laravel-console-dusk.php' => config_path('laravel-console-dusk.php'),
             ], 'config');

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -26,7 +26,7 @@ class Manager implements ManagerContract
         $this->browserFactory = $browserFactory ?: new ConsoleBrowserFactory();
     }
 
-    public function browse(Command $command, Closure $callback): void
+    public function browse(Command|null $command, Closure $callback): void
     {
         $this->driver->open();
 
@@ -46,8 +46,13 @@ class Manager implements ManagerContract
         }
     }
 
+    public function browseWithoutCommand(Closure $callback): void
+    {
+        $this->browse(null, $callback);
+    }
+
     /** @return Collection<int, ConsoleBrowserContract> */
-    protected function createBrowsers(Command $command, Closure $callback): Collection
+    protected function createBrowsers(Command|null $command, Closure $callback): Collection
     {
         $browsers = collect();
 


### PR DESCRIPTION
Over the years there have been a number of discussions about using Laravel-Console-Dusk in non-Artisan contexts, e.g. in a queue. I had this need recently and as far as I can tell, the only thing that really prevents people from doing this is the reliance on `nunomaduro/laravel-console-task` for the pretty-printing of the progress messages.

This PR makes the provision of a `Command` object optional, and allows Laravel-Console-Dusk to boot even in non-console contexts (by way of a configuration option).  In non-Artisan contexts, it will not use `laravel-console-task` for reporting.  

Likely resolves #4 and #17.  It seems to be working for our purposes, but I am open to any suggestions on how we might differently architect this.  
